### PR TITLE
fix bugs when input fastq files

### DIFF
--- a/src/kseq.h
+++ b/src/kseq.h
@@ -201,7 +201,6 @@ typedef struct __kstring_t {
 		} \
 		seq->seq.s[seq->seq.l] = 0;	/* null terminated string */ \
 		if (c != '+') return seq->seq.l; /* FASTA */ \
-		fprintf(stderr,"notfa");\
 		if (seq->qual.m < seq->seq.m) {	/* allocate memory for qual in case insufficient */ \
 			seq->qual.m = seq->seq.m; \
 			seq->qual.s = (char*)realloc(seq->qual.s, seq->qual.m); \


### PR DESCRIPTION
```
modified:   src/kseq.h
```

Just delete this line so that "notfa" will not be printed a quantity of times while loading a fastq read file.
